### PR TITLE
Enable scenario loading into simulation forms

### DIFF
--- a/vite-react-frontend/src/pages/ExplorePage.tsx
+++ b/vite-react-frontend/src/pages/ExplorePage.tsx
@@ -1,5 +1,7 @@
 // src/pages/ExplorePage.tsx
 import React, { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { convertToNormalFormData, convertToAdvancedFormData } from '../utils/scenarioLoader';
 
 type OverallTaxRule = 'CAPITAL' | 'NOTIONAL';
 type TaxToggle = 'EXEMPTIONCARD' | 'STOCKEXEMPTION';
@@ -312,11 +314,40 @@ const OutputsCell: React.FC<{ outputs: OutputPoint[] }> = ({ outputs }) => {
 };
 
 const ExplorePage: React.FC = () => {
+  const navigate = useNavigate();
+  
   // Under development banner
   const [ack, setAck] = useState(false);
 
   // (Optional) simple search across inputs text
   const [query, setQuery] = useState('');
+
+  /**
+   * Handles loading a scenario into the simulation form.
+   * 
+   * This function:
+   * 1. Converts the scenario's PhaseInput format to the form's PhaseRequest format
+   * 2. Navigates to the simulation page with the scenario data in location state
+   * 3. The SimulationPage will detect this data and populate the form accordingly
+   * 
+   * @param scenarioInputs - The input data from the selected scenario
+   */
+  const handleLoadScenario = (scenarioInputs: SimulationInputs) => {
+    // Convert scenario data to both normal and advanced form formats
+    // The SimulationPage will use the appropriate format based on the current form mode
+    const normalData = convertToNormalFormData(scenarioInputs);
+    const advancedData = convertToAdvancedFormData(scenarioInputs);
+    
+    // Navigate to simulation page with scenario data in location state
+    navigate('/simulation', {
+      state: {
+        scenarioData: {
+          normal: normalData,
+          advanced: advancedData,
+        },
+      },
+    });
+  };
 
   const rows = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -419,8 +450,20 @@ const ExplorePage: React.FC = () => {
                     <button type="button" title="Open details (coming soon)" disabled style={{ padding: '6px 8px' }}>
                       View
                     </button>
-                    <button type="button" title="Clone into form (coming soon)" disabled style={{ padding: '6px 8px' }}>
-                      Clone
+                    <button
+                      type="button"
+                      title="Load this scenario into the simulation form"
+                      onClick={() => handleLoadScenario(r.inputs)}
+                      style={{
+                        padding: '6px 8px',
+                        border: '1px solid #444',
+                        backgroundColor: '#2e2e2e',
+                        color: '#fff',
+                        cursor: 'pointer',
+                        borderRadius: 4,
+                      }}
+                    >
+                      Load
                     </button>
                     <button type="button" title="Download CSV (coming soon)" disabled style={{ padding: '6px 8px' }}>
                       CSV

--- a/vite-react-frontend/src/utils/scenarioLoader.ts
+++ b/vite-react-frontend/src/utils/scenarioLoader.ts
@@ -1,0 +1,134 @@
+/**
+ * Utility functions for loading scenario data into forms.
+ * 
+ * This module handles the conversion between scenario data formats
+ * (from ExplorePage) and form input formats (for NormalInputForm and AdvancedInputForm).
+ */
+
+import { PhaseRequest } from '../models/types';
+
+/**
+ * PhaseInput type from ExplorePage scenarios
+ */
+export type PhaseInput = {
+  type: 'DEPOSIT' | 'PASSIVE' | 'WITHDRAW';
+  durationInMonths: number;
+  // DEPOSIT fields
+  initialDeposit?: number;
+  monthlyDeposit?: number;
+  yearlyIncreasePercent?: number;
+  // WITHDRAW fields
+  withdrawAmount?: number;
+  lowerVariationPercent?: number;
+  upperVariationPercent?: number;
+  // Shared
+  taxRules?: ('EXEMPTIONCARD' | 'STOCKEXEMPTION')[];
+};
+
+/**
+ * SimulationInputs type from ExplorePage scenarios
+ */
+export type SimulationInputs = {
+  startDate: string; // ISO yyyy-mm-dd
+  overallTaxRule: 'CAPITAL' | 'NOTIONAL';
+  taxPercentage: number;
+  phases: PhaseInput[];
+};
+
+/**
+ * Converts a PhaseInput (from scenario) to PhaseRequest (for form submission).
+ * 
+ * Handles field name differences:
+ * - type -> phaseType
+ * - yearlyIncreasePercent -> yearlyIncreaseInPercentage
+ * - lowerVariationPercent -> lowerVariationPercentage
+ * - upperVariationPercent -> upperVariationPercentage
+ * 
+ * @param phaseInput - Phase data from scenario
+ * @returns PhaseRequest compatible with form submission
+ */
+export function convertPhaseInputToPhaseRequest(phaseInput: PhaseInput): PhaseRequest {
+  const phase: PhaseRequest = {
+    phaseType: phaseInput.type,
+    durationInMonths: phaseInput.durationInMonths,
+    taxRules: phaseInput.taxRules || [],
+  };
+
+  // DEPOSIT-specific fields
+  if (phaseInput.type === 'DEPOSIT') {
+    if (phaseInput.initialDeposit !== undefined) {
+      phase.initialDeposit = phaseInput.initialDeposit;
+    }
+    if (phaseInput.monthlyDeposit !== undefined) {
+      phase.monthlyDeposit = phaseInput.monthlyDeposit;
+    }
+    if (phaseInput.yearlyIncreasePercent !== undefined) {
+      phase.yearlyIncreaseInPercentage = phaseInput.yearlyIncreasePercent;
+    }
+  }
+
+  // WITHDRAW-specific fields
+  if (phaseInput.type === 'WITHDRAW') {
+    if (phaseInput.withdrawAmount !== undefined) {
+      phase.withdrawAmount = phaseInput.withdrawAmount;
+    }
+    if (phaseInput.lowerVariationPercent !== undefined) {
+      phase.lowerVariationPercentage = phaseInput.lowerVariationPercent;
+    }
+    if (phaseInput.upperVariationPercent !== undefined) {
+      phase.upperVariationPercentage = phaseInput.upperVariationPercent;
+    }
+  }
+
+  return phase;
+}
+
+/**
+ * Converts SimulationInputs (from scenario) to initial data for NormalInputForm.
+ * 
+ * @param inputs - Scenario input data
+ * @returns Initial form data for NormalInputForm
+ */
+export function convertToNormalFormData(inputs: SimulationInputs) {
+  return {
+    startDate: inputs.startDate,
+    overallTaxRule: inputs.overallTaxRule,
+    taxPercentage: inputs.taxPercentage,
+    phases: inputs.phases.map(convertPhaseInputToPhaseRequest),
+  };
+}
+
+/**
+ * Converts SimulationInputs (from scenario) to initial data for AdvancedInputForm.
+ * 
+ * Note: AdvancedInputForm uses a dynamic form config from the backend, so we
+ * map the scenario data to the expected form structure.
+ * 
+ * @param inputs - Scenario input data
+ * @returns Initial form data for AdvancedInputForm
+ */
+export function convertToAdvancedFormData(inputs: SimulationInputs) {
+  return {
+    startDate: inputs.startDate,
+    taxRule: inputs.overallTaxRule.toLowerCase(), // Advanced form expects lowercase
+    tax: {
+      percentage: inputs.taxPercentage,
+    },
+    phases: inputs.phases.map((p) => ({
+      phaseType: p.type,
+      durationInMonths: p.durationInMonths,
+      initialDeposit: p.initialDeposit,
+      monthlyDeposit: p.monthlyDeposit,
+      yearlyIncreaseInPercentage: p.yearlyIncreasePercent,
+      withdrawAmount: p.withdrawAmount,
+      lowerVariationPercentage: p.lowerVariationPercent,
+      upperVariationPercentage: p.upperVariationPercent,
+      taxExemptions: p.taxRules?.length
+        ? p.taxRules.length === 2
+          ? 'BOTH'
+          : p.taxRules[0]
+        : undefined,
+    })),
+  };
+}
+


### PR DESCRIPTION
Implements the ability to load example scenarios from ExplorePage directly into both Normal and Advanced simulation forms. Adds scenarioLoader utility for converting scenario data to form-compatible formats, updates SimulationPage to accept and clear scenario data from navigation state, and updates both input forms to initialize and reset state based on loaded scenarios.