### PR TITLE
fix: bump CI Node.js to 20.x for Vite 7 / Tailwind v4 compatibility

### DIFF
--- a/.github/workflows/install_build_react.yml
+++ b/.github/workflows/install_build_react.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           cache: 'npm'
           cache-dependency-path: vite-react-frontend/package-lock.json
 


### PR DESCRIPTION
Vite 7 requires Node 20.19+/22.12+; the CI job was still pinned to 18.x, which also surfaces npm's documented optional-dependency resolution bug for @tailwindcss/oxide's platform-specific native bindings. Matches the Node 20-alpine base image already used in the production Dockerfile.